### PR TITLE
Actions Workflow: Update Python version and explicitly calling Ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,7 @@ on:
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
   deploy-book:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,10 +21,10 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install dependencies
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.15
+        python-version: 3.11.11
         
     - name: Install dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![logo](lecture/static/logo.png)
 
-
 ## "What's in this repository?"
 
 This is the readme of the French version of the Psychoacoustic textbook: https://leovarnet.github.io/psychoac-manuel-fr/


### PR DESCRIPTION
Workflow failed with Error: Version 3.10.15 with arch x64 not found, therefore updated the workflow to use 3.11.11 (x64) instead. 