### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book
+jupyter-book<2.0.0
 matplotlib
 numpy
 sphinx-inline-tabs


### PR DESCRIPTION
Hey Leo, 

here the fix for automatic build using the github pages workflow.

The release of Jupyter Book 2.0 broke most workflows. Indicating in the requirements.txt that we'd like to use jupyter-book<2.0.0, solves this issue. 

